### PR TITLE
The script fails when a docker daemon is not reachable/communicatible

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -eo pipefail
+
 #usage: sudo ./docker-cleanup-volumes.sh [--dry-run]
 
 dockerdir=/var/lib/docker
@@ -57,6 +59,8 @@ else if [ -n "$1" ]; then
 fi
 fi
 
+# Make sure that we can talk to docker daemon. If we cannot, we fail here.
+docker info >/dev/null
 
 #All volumes from all containers
 for container in `${docker_bin} ps -a -q --no-trunc`; do


### PR DESCRIPTION
Currently, if the docker client cannot communicate with the daemon, it will remove all docker volumes.

The correct behavior is: the script fails if the docker client cannot talk to the daemon.

Fixes https://github.com/chadoe/docker-cleanup-volumes/issues/3.
