### PR TITLE
A docker client version can be specified in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ FROM debian:jessie
 
 MAINTAINER Martin van Beurden <chadoe@gmail.com>
 
+ENV DOCKER_VERSION=1.5.0
+
 #Install an up to date version of docker
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
     echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list && \
-    apt-get update && apt-get install -y lxc-docker && \
+    apt-get update && apt-get install -y lxc-docker-$DOCKER_VERSION && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 #Add the cleanup script


### PR DESCRIPTION
The pull request allows to specify the docker client version to be installed. Currently it is set to 1.5.0.

By the way, it would be awesome, if you will  tag your docker container with the docker client version it has installed. E.g.:
- `martin/docker-cleanup-volumes:1.4.1` for docker client 1.4.1
- `martin/docker-cleanup-volumes:1.5.0` and `martin/docker-cleanup-volumes:latest` for docker client 1.5.0
