### PR TITLE
Use leaner alpine:3.1 as Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@
 #Usage:
 #docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes [--dry-run]
 #
-FROM debian:jessie
+FROM alpine:3.1
 
 MAINTAINER Martin van Beurden <chadoe@gmail.com>
 
 ENV DOCKER_VERSION=1.5.0
 
 #Install an up to date version of docker
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
-    echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list && \
-    apt-get update && apt-get install -y lxc-docker-$DOCKER_VERSION && \
-	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk add --update-cache curl bash grep && rm -rf /var/cache/apk/*
+# the docker package in alpine disables aufs and devicemapper
+RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION -o /usr/bin/docker && \
+  chmod +x /usr/bin/docker
 
 #Add the cleanup script
 ADD ./docker-cleanup-volumes.sh /usr/local/bin/

--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -73,7 +73,7 @@ for container in `${docker_bin} ps -a -q --no-trunc`; do
                         allvolumes+=("${vid##*/}")
                 else
                         #check if it's a bindmount, these have a config.json file in the ${volumesdir} but no files in ${vfsdir}
-                        for bmv in `grep --include config.json -Rl "\"IsBindMount\":true" ${volumesdir} | xargs -i grep -l "\"Path\":\"${vid}\"" {}`; do
+                        for bmv in `grep --include config.json -Rl "\"IsBindMount\":true" ${volumesdir} | xargs grep -l "\"Path\":\"${vid}\""`; do
                                 bmv="$(basename "$(dirname "${bmv}")")"
                                 allvolumes+=("${bmv}")
                                 #there should be only one config for the bindmount, delete any duplicate for the same bindmount.


### PR DESCRIPTION
The alpine linux distribution is very small and well-suited for Docker images. 

``` console
$ docker images
REPOSITORY                 TAG       IMAGE ID            CREATED             VIRTUAL SIZE
docker-cleanup-volumes     alpine    ac7a0ef13469        9 seconds ago       24.44 MB
docker-cleanup-volumes     debian    76f6538ac10d        2 minutes ago       234.6 MB
```

See deis/deis#3716.
