### PR TITLE
Find Docker configuration folder automatically

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 #usage: sudo ./docker-cleanup-volumes.sh [--dry-run]
 
-dockerdir=/var/lib/docker
+dockerdir=`docker info | grep "Data loop file" | sed "s/\/devicemapper.*//" | sed "s/.* //"`
 volumesdir=${dockerdir}/volumes
 vfsdir=${dockerdir}/vfs/dir
 allvolumes=()


### PR DESCRIPTION
The docker configuration files are not always at /var/lib/docker (it's almost never the case in my production environments)

The easiest way I found to get this information is to use the `docker info` command.
