### PR TITLE
Switch to find & remove globbing for directories

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -28,7 +28,7 @@ function delete_volumes() {
         return
   fi
   echo "Delete unused volume directories from $targetdir"
-  for dir in $(ls -d ${targetdir}/* 2>/dev/null)
+  for dir in $(find ${targetdir} -type d 2>/dev/null)
   do
         dir=$(basename $dir)
         if [[ "${dir}" =~ [0-9a-f]{64} ]]; then
@@ -112,4 +112,3 @@ done
 
 delete_volumes ${volumesdir}
 delete_volumes ${vfsdir}
-

--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -28,7 +28,7 @@ function delete_volumes() {
         return
   fi
   echo "Delete unused volume directories from $targetdir"
-  for dir in $(find ${targetdir} -type d 2>/dev/null)
+  for dir in $(find ${targetdir} -maxdepth 1 -type d 2>/dev/null)
   do
         dir=$(basename $dir)
         if [[ "${dir}" =~ [0-9a-f]{64} ]]; then


### PR DESCRIPTION
Having over 20k directories would result in 'argument list too long' as the glob would expand them on the command line. Switched this over to find type directory. 
