### PR TITLE
Avoid "grep: warn: recursive directory loop" by using find instead

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -132,7 +132,7 @@ for container in $container_ids; do
                         allvolumes+=("${vid}")
                 else
                         #check if it's a bindmount, these have a config.json file in the ${volumesdir} but no files in ${vfsdir} (docker 1.6.2 and below)
-                        for bmv in `grep --include config.json -Rl "\"IsBindMount\":true" ${volumesdir} | xargs grep -l "\"Path\":\"${volpath}\""`; do
+                        for bmv in `find ${volumesdir} -name config.json | xargs grep -l "\"IsBindMount\":true" | xargs grep -l "\"Path\":\"${volpath}\""`; do
                                 bmv="$(basename "$(dirname "${bmv}")")"
                                 log_verbose "Found bindmount ${bmv}"
                                 allvolumes+=("${bmv}")


### PR DESCRIPTION
Symlinks inside the Docker graph may be nonsense when viewed from outside
