### PR TITLE
Avoid problems when /var/lib/docker is symlinked

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -125,9 +125,9 @@ for container in $container_ids; do
 	); do
                 log_verbose "Processing volumepath ${volpath} for container ${container}"
 		#try to get volume id from the volume path
-		vid=$(echo "${volpath}"|sed "s|${vfsdir_match}||;s|${volumesdir_match}||;s/.*\([0-9a-f]\{64\}\).*/\1/")
+		vid=$(echo "${volpath}"|sed "s|${vfsdir_match}||;s|${volumesdir_match}||;s/.*\/\([0-9a-f]\{64\}\)\$/\1/")
                 # host daemon shows original dir path - this is why _match variables are used:
-                if [[ (${volpath} == ${vfsdir_match}* || ${volpath} == ${volumesdir_match}*) && "${vid}" =~ [0-9a-f]{64} ]]; then
+                if [[ "${vid}" =~ [0-9a-f]{64} ]]; then
                         log_verbose "Found volume ${vid}"
                         allvolumes+=("${vid}")
                 else


### PR DESCRIPTION
When /var/lib/docker is symlinked and it's not feasible to use readlink, the volumesdir_match/vfsdir_match causes the script to delete volumes that are in use. 

This patch removes the extra prefix check of the volume mount, and instead checks that the mount ends with a 64 character directory name. The result is that readlink is not needed to avoid problems when _/var/lib/docker_ is symlinked. 

Note that it could theoretically cause "false negatives" if an unrelated 64 char directory is mounted, and it happens to have the same 64 char name as a real docker volume. However since Docker generates the 64 char volume id as a UUID, the chance to get a collision like this is in practice impossible.

The background is that we're using Puppet with the garethr-docker module to run docker-cleanup-volumes. Mounting a volume like _"$(readlink -f /var/lib/docker):/var/lib/docker:rw"_ doesn't work since systemd unit files aren't evaluated as scripts. It does work fine on pre-systemd Linuxes when an init.d script is created, which will then evaluate _$(readlink ..)_
