### PR TITLE
enhance docker directory detection (parse option '--graph=...')

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -13,6 +13,8 @@ dockerdir=/var/lib/docker
 dockerPs=`ps aux | grep $docker_bin | grep -v grep` || :
 if [[ $dockerPs =~ ' -g ' ]]; then
 	dockerdir=`echo $dockerPs | sed 's/.* -g//' | cut -d ' ' -f 2`
+elif [[ $dockerPs =~ ' --graph=' ]]; then
+    dockerdir=`echo $dockerPs | sed 's/.* --graph//' | cut -d '=' -f 2 | awk '{print $1}'`
 fi
 
 dockerdir=$(readlink -f $dockerdir)


### PR DESCRIPTION
Docker daemon can be started with the option '--graph=/some/directory'. This
is equivalent to '-g' and must also be parsed to detect the proper docker directory location.

Change-Id: If9e56b30e01ec1872ad80a60e04f81352c18ed4d
Signed-off-by: Stephane Desneux stephane.desneux@iot.bzh
