### PR TITLE
redirected all output from docker info to /dev/null

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -92,7 +92,7 @@ do
 done
 
 # Make sure that we can talk to docker daemon. If we cannot, we fail here.
-${docker_bin} info >/dev/null
+${docker_bin} info &>/dev/null
 
 container_ids=$(${docker_bin} ps -a -q --no-trunc)
 


### PR DESCRIPTION
Script was throwing " WARNING: bridge-nf-call-iptables is disabled" and "WARNING: bridge-nf-call-ip6tables is disabled " so I decided to redirect all output from docker info to /dev/null instead of only the stdout. 
