### PR TITLE
fix directory handling, syntax cleanup, local var scope

### DIFF
--- a/docker-cleanup-volumes.sh
+++ b/docker-cleanup-volumes.sh
@@ -4,20 +4,30 @@ set -eou pipefail
 
 #usage: sudo ./docker-cleanup-volumes.sh [--dry-run]
 
-docker_bin=$(which docker.io 2> /dev/null || which docker 2> /dev/null)
+docker_bin="$(which docker.io 2> /dev/null || which docker 2> /dev/null)"
 
 # Default dir
 dockerdir=/var/lib/docker
 
-# Look for an alternate docker directory with -g option
-dockerPs=`ps aux | grep $docker_bin | grep -v grep` || :
-if [[ $dockerPs =~ ' -g ' ]]; then
-	dockerdir=`echo $dockerPs | sed 's/.* -g//' | cut -d ' ' -f 2`
-elif [[ $dockerPs =~ ' --graph=' ]]; then
-    dockerdir=`echo $dockerPs | sed 's/.* --graph//' | cut -d '=' -f 2 | awk '{print $1}'`
+# Look for an alternate docker directory with -g/--graph option
+dockerpid=$(ps ax | grep "$docker_bin" | grep -v grep | awk '{print $1; exit}') || :
+if [[ -n "$dockerpid" && $dockerpid -gt 0 ]]; then
+    next_arg_is_dockerdir=false
+    while read -d $'\0' arg
+    do
+        if [[ $arg =~ ^--graph=(.+) ]]; then
+            dockerdir=${BASH_REMATCH[1]}
+            break
+        elif [ $arg = '-g' ]; then
+            next_arg_is_dockerdir=true
+        elif [ $next_arg_is_dockerdir = true ]; then
+            dockerdir=$arg
+            break
+        fi
+    done < /proc/$dockerpid/cmdline
 fi
 
-dockerdir=$(readlink -f $dockerdir)
+dockerdir=$(readlink -f "$dockerdir")
 
 volumesdir=${dockerdir}/volumes
 vfsdir=${dockerdir}/vfs/dir
@@ -32,16 +42,17 @@ function log_verbose() {
 }
 
 function delete_volumes() {
-  targetdir=$1
+  local targetdir=$1
   echo
-  if [[ ! -d ${targetdir} || ! "$(ls -A ${targetdir})" ]]; then
+  if [[ ! -d "${targetdir}" || ! "$(ls -A "${targetdir}")" ]]; then
         echo "Directory ${targetdir} does not exist or is empty, skipping."
         return
   fi
   echo "Delete unused volume directories from $targetdir"
-  for dir in $(find ${targetdir} -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+  local dir
+  while read -d $'\0' dir
   do
-        dir=$(basename $dir)
+        dir=$(basename "$dir")
         if [[ -d "${targetdir}/${dir}/_data" || "${dir}" =~ [0-9a-f]{64} ]]; then
                 if [ ${#allvolumes[@]} -gt 0 ] && [[ ${allvolumes[@]} =~ "${dir}" ]]; then
                         echo "In use ${dir}"
@@ -56,7 +67,7 @@ function delete_volumes() {
         else
                 echo "Not a volume ${dir}"
         fi
-  done
+  done < <(find "${targetdir}" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
 }
 
 if [ $UID != 0 ]; then
@@ -110,14 +121,14 @@ for container in $container_ids; do
         ); do
                 log_verbose "Processing volumepath ${volpath} for container ${container}"
                 #try to get volume id from the volume path
-                vid=$(echo "${volpath}"|sed 's|.*/\(.*\)/_data$|\1|;s|.*/\([0-9a-f]\{64\}\)$|\1|')
+                vid=$(echo "${volpath}" | sed 's|.*/\(.*\)/_data$|\1|;s|.*/\([0-9a-f]\{64\}\)$|\1|')
                 # check for either a 64 character vid or then end of a volumepath containing _data:
                 if [[ "${vid}" =~ ^[0-9a-f]{64}$ || (${volpath} =~ .*/_data$ && ! "${vid}" =~ "/") ]]; then
                         log_verbose "Found volume ${vid}"
                         allvolumes+=("${vid}")
                 else
                         #check if it's a bindmount, these have a config.json file in the ${volumesdir} but no files in ${vfsdir} (docker 1.6.2 and below)
-                        for bmv in $(find ${volumesdir} -name config.json -print | xargs grep -l "\"IsBindMount\":true" | xargs grep -l "\"Path\":\"${volpath}\""); do
+                        for bmv in $(find "${volumesdir}" -name config.json -print | xargs grep -l "\"IsBindMount\":true" | xargs grep -l "\"Path\":\"${volpath}\""); do
                                 bmv="$(basename "$(dirname "${bmv}")")"
                                 log_verbose "Found bindmount ${bmv}"
                                 allvolumes+=("${bmv}")
@@ -129,6 +140,5 @@ for container in $container_ids; do
 done
 IFS=$SAVEIFS
 
-delete_volumes ${volumesdir}
-delete_volumes ${vfsdir}
-
+delete_volumes "${volumesdir}"
+delete_volumes "${vfsdir}"


### PR DESCRIPTION
This PR implements:
- directory handling for $dockerdir with spaces in the path
- cleanup command substitution syntax from using backticks to bash style `$()` as that seems to be the syntax used in the rest of the script
- change variables used only within functions to not leak outside the local scope of the function
